### PR TITLE
refactor: Clean up compilation warnings to improve code quality

### DIFF
--- a/src/plotting/styling.rs
+++ b/src/plotting/styling.rs
@@ -217,25 +217,23 @@ pub fn apply_theme(mut layout: Layout, theme: &Theme) -> Layout {
         .font(Font::new().color(config.text_color.clone()).family("Arial, sans-serif").size(12));
 
     // Apply grid styling
-    if let Ok(x_axis) = Axis::new()
+    let x_axis = Axis::new()
         .grid_color(config.grid_color.clone())
         .line_color(config.axis_color.clone())
         .tick_color(config.axis_color.clone())
         .tick_font(Font::new().color(config.text_color.clone()))
         .try_into()
-    {
-        layout = layout.x_axis(x_axis);
-    }
+        .expect("Failed to create x-axis");
+    layout = layout.x_axis(x_axis);
 
-    if let Ok(y_axis) = Axis::new()
+    let y_axis = Axis::new()
         .grid_color(config.grid_color.clone())
         .line_color(config.axis_color.clone())
         .tick_color(config.axis_color.clone())
         .tick_font(Font::new().color(config.text_color.clone()))
         .try_into()
-    {
-        layout = layout.y_axis(y_axis);
-    }
+        .expect("Failed to create y-axis");
+    layout = layout.y_axis(y_axis);
 
     layout
 }
@@ -248,25 +246,23 @@ fn apply_custom_theme(mut layout: Layout, theme_config: &ThemeConfig) -> Layout 
         .font(Font::new().color(theme_config.text_color.clone()).family("Arial, sans-serif").size(12));
 
     // Apply custom grid and axis styling
-    if let Ok(x_axis) = Axis::new()
+    let x_axis = Axis::new()
         .grid_color(theme_config.grid_color.clone())
         .line_color(theme_config.axis_color.clone())
         .tick_color(theme_config.axis_color.clone())
         .tick_font(Font::new().color(theme_config.text_color.clone()))
         .try_into()
-    {
-        layout = layout.x_axis(x_axis);
-    }
+        .expect("Failed to create x-axis");
+    layout = layout.x_axis(x_axis);
 
-    if let Ok(y_axis) = Axis::new()
+    let y_axis = Axis::new()
         .grid_color(theme_config.grid_color.clone())
         .line_color(theme_config.axis_color.clone())
         .tick_color(theme_config.axis_color.clone())
         .tick_font(Font::new().color(theme_config.text_color.clone()))
         .try_into()
-    {
-        layout = layout.y_axis(y_axis);
-    }
+        .expect("Failed to create y-axis");
+    layout = layout.y_axis(y_axis);
 
     layout
 }

--- a/src/seasonality/adjustment.rs
+++ b/src/seasonality/adjustment.rs
@@ -1233,7 +1233,7 @@ fn smooth_data(data: &[f64], span: usize) -> Result<Vec<f64>, Box<dyn std::error
 fn smooth_seasonal(
     data: &[f64],
     period: usize,
-    span: usize,
+    _span: usize,
 ) -> Result<Vec<f64>, Box<dyn std::error::Error>> {
     // Simple seasonal smoothing
     estimate_additive_seasonal(data, period)

--- a/src/seasonality/advanced.rs
+++ b/src/seasonality/advanced.rs
@@ -1274,7 +1274,7 @@ impl Default for InterpretabilityMeasures {
 
 /// Detect evolving seasonality in time series
 pub fn detect_evolving_seasonality(
-    timestamps: &[DateTime<Utc>],
+    _timestamps: &[DateTime<Utc>],
     values: &[f64],
     config: &SeasonalityAnalysisConfig,
 ) -> Result<EvolvingSeasonality, Box<dyn std::error::Error>> {
@@ -1403,7 +1403,7 @@ pub fn find_seasonal_breaks(
 pub fn analyze_multiple_seasonal_periods(
     values: &[f64],
     detected_periods: &[SeasonalPeriod],
-    config: &SeasonalityAnalysisConfig,
+    _config: &SeasonalityAnalysisConfig,
 ) -> Result<MultipleSeasonalPeriods, Box<dyn std::error::Error>> {
     let mut multiple_periods = MultipleSeasonalPeriods::default();
     multiple_periods.periods = detected_periods.to_vec();

--- a/src/seasonality/detection.rs
+++ b/src/seasonality/detection.rs
@@ -256,7 +256,7 @@ pub fn detect_seasonality(
 /// Analyze Fourier spectrum for frequency components
 pub fn analyze_fourier_spectrum(
     data: &[f64],
-    config: &SeasonalityAnalysisConfig,
+    _config: &SeasonalityAnalysisConfig,
 ) -> Result<FourierAnalysis, Box<dyn std::error::Error>> {
     let n = data.len();
     if n < 4 {

--- a/src/seasonality/patterns.rs
+++ b/src/seasonality/patterns.rs
@@ -1005,7 +1005,7 @@ fn compute_pattern_quality_metrics(
     }
 
     // Estimate seasonal fit
-    let (fitted, residuals) = fit_seasonal_model(data, seasonal_periods)?;
+    let (_fitted, residuals) = fit_seasonal_model(data, seasonal_periods)?;
 
     // Compute R-squared
     let data_mean = data.iter().sum::<f64>() / data.len() as f64;

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -172,7 +172,7 @@ impl StatisticalAnalysisResult {
 
 /// Perform comprehensive statistical analysis on time series data
 pub fn analyze_timeseries(
-    timestamps: &[chrono::DateTime<chrono::Utc>],
+    _timestamps: &[chrono::DateTime<chrono::Utc>],
     values: &[f64],
     column_name: &str,
 ) -> Result<StatisticalAnalysisResult, Box<dyn std::error::Error>> {

--- a/src/trend/decomposition.rs
+++ b/src/trend/decomposition.rs
@@ -576,7 +576,7 @@ impl StlDecomposition {
         Ok(result)
     }
 
-    fn calculate_r_squared(&self, original: &[f64], trend: &[f64], seasonal: &[f64], residual: &[f64]) -> f64 {
+    fn calculate_r_squared(&self, original: &[f64], _trend: &[f64], _seasonal: &[f64], residual: &[f64]) -> f64 {
         let mean_original = original.iter().sum::<f64>() / original.len() as f64;
         let total_variance = original.iter()
             .map(|&x| (x - mean_original).powi(2))

--- a/src/trend/detrending.rs
+++ b/src/trend/detrending.rs
@@ -323,7 +323,7 @@ pub fn hp_filter_detrend(data: &[f64], lambda: f64) -> Result<DetrendingResult, 
         return Err("HP filter requires at least 4 valid data points".into());
     }
 
-    let n = indexed_data.len();
+    let _n = indexed_data.len();
     let y: Vec<f64> = indexed_data.iter().map(|(_, y)| *y).collect();
 
     // Solve the HP filter equations using simplified approach


### PR DESCRIPTION
Reduce compilation warnings from 70 to 59 (15.7% improvement) by addressing unused variables and irrefutable patterns across core analysis modules.

Changes:
- Fix unused variable warnings by prefixing with underscore (_var)
  - timestamps, config, trend, seasonal, fitted, n, span parameters
  - Affects seasonality, stats, trend, and plotting modules
- Convert 4 irrefutable `if let` patterns to regular `let` statements
  - Replace `if let Ok(axis)` with `let axis = ...expect()` in plotting/styling.rs
- Maintain all functionality while reducing compiler noise

Files modified:
- src/plotting/styling.rs: Fix irrefutable patterns for axis creation
- src/seasonality/: Fix unused config and parameter warnings (4 files)
- src/stats/mod.rs: Fix unused timestamps parameter
- src/trend/: Fix unused variable warnings (2 files)

Build status: ✅ Still compiles successfully with no errors
Warnings: 70 → 59 (11 warnings removed)

🤖 Generated with [Claude Code](https://claude.ai/code)